### PR TITLE
Add missing dependency domready to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "backbone": "^1.1.2",
     "browserify": "^8.1.1",
+    "domready": "^1.0.7",
     "express": "^4.11.1",
     "jade": "^1.9.1",
     "jquery": "^2.1.3",


### PR DESCRIPTION
@kwhinnery, dependency 'domready' was missing resulting in the `/require.js` route returning a 500 error.
